### PR TITLE
Search a sequence of arrays of FuseProps without using a key path

### DIFF
--- a/Documentation/FuseInstructions.md
+++ b/Documentation/FuseInstructions.md
@@ -78,7 +78,85 @@ fuse.search("Te silm", in: books, completion: { results in
 })
 ```
 
-#### Search in `[Searchable]` objects - how to use `FuseProp`
+#### Search in `[[FuseProp]]`
+
+A `FuseProp` is a struct of searchable values and the weights to assign to them.
+
+```swift
+public struct FuseProp : Sendable {
+    public let value: String
+    public let weight: Double
+    
+    public init (_ value: String, weight: Double = 1.0) {
+        self.value = value
+        
+        self.weight = weight
+    }
+}
+```
+
+So, suppose you have an array of `Book` objects, like this:
+
+```swift
+struct Book {
+    let author: String
+    let title: String
+}
+
+let books: [Book] = [
+    Book(author: "John X", title: "Old Man's War fiction"),
+    Book(author: "P.D. Mans", title: "Right Ho Jeeves")
+]
+```
+
+You could convert each book to an array of `FuseProp` objects and search them like this:
+
+```swift
+let fuseProps = books.lazy.map({book in 
+    [
+        FuseProp(value: book.title),
+        FuseProp(value: book.author),
+    ]
+})
+
+let fuse = Fuse()
+
+// --------------------
+// SYNC version
+let resultsSync = fuse.searchSync("man", in: fuseProps)
+
+resultsSync.forEach { item in
+    print("index: \(item.index); score: \(item.diffScore)")
+}
+
+// --------------------
+// ASYNC: async/await
+let resultsAsync = await fuse.search("Man", in: fuseProps)
+
+resultsAsync.forEach { item in
+    print("index: \(item.index); score: \(item.diffScore)")
+}
+
+// ASYNC: callbacks
+fuse.search("Man", in: fuseProps, completion: { results in
+    results.forEach { item in
+        print("index: \(item.index); score: \(item.diffScore)")
+    }
+})
+```
+
+You can also add weights to your `FuseProp` objects. This example would prioritize author matches over title matches:
+
+```swift
+let fuseProps = books.map({book in 
+    [
+        FuseProp(value: book.title, weight: 0.3),
+        FuseProp(value: book.author, weight: 0.7),
+    ]
+})
+```
+
+#### Search in `[Searchable]` objects
 
 Declaration of `Searchable` object:
 

--- a/Sources/Ifrit/Classes/Fuse+/Fuse+ArrObjects.swift
+++ b/Sources/Ifrit/Classes/Fuse+/Fuse+ArrObjects.swift
@@ -7,43 +7,9 @@ extension Fuse {
     /// instructions how to use: https://github.com/ukushu/Ifrit/blob/main/Docs/FuseInstructions.md
     ///
     public func searchSync<T>(_ text: String, in aList: [T], by keyPath: KeyPath<T, [FuseProp]>) -> [FuzzySrchResult]  where T: Searchable {
-        let pattern = self.createPattern(from: text)
-        
-        var collectionResult = [FuzzySrchResult]()
-        
-        for (index, item) in aList.enumerated() {
-            var scores = [Double]()
-            var totalScore = 0.0
-            
-            var propertyResults = [(value: String, diffScore: Double, ranges: [CountableClosedRange<Int>])]()
-            
-            item[keyPath: keyPath].forEach { property in
-                
-                let value = property.value
-                
-                if let result = self.search(pattern, in: value) {
-                    let weight = property.weight == 1 ? 1 : 1 - property.weight
-                    let score = (result.score == 0 && weight == 1 ? 0.001 : result.score) * weight
-                    totalScore += score
-                    
-                    scores.append(score)
-                    
-                    propertyResults.append((value: property.value, diffScore: score, ranges: result.ranges))
-                }
-            }
-            
-            if scores.count == 0 {
-                continue
-            }
-            
-            collectionResult.append((
-                index: index,
-                diffScore: self.objSortStrategy == .averageScore ? totalScore / Double(scores.count) : scores.min() ?? 1 ,
-                results: propertyResults
-            ))
-        }
-        
-        return collectionResult.sorted { $0.diffScore < $1.diffScore }
+        return self.searchSync(text, in: aList.lazy.map({item in
+            item[keyPath: keyPath]
+        }))
     }
     
     ///
@@ -55,62 +21,10 @@ extension Fuse {
                           chunkSize: Int = 100,
                           completion: @escaping @Sendable ([FuzzySrchResult]) -> Void) where T: Searchable
     {
-        let pattern = self.createPattern(from: text )
-        
-        let group = DispatchGroup()
-        
-        var collectionResult = [FuzzySrchResult]()
-        let resultLock = NSLock()
-        
-        aList.splitBy(chunkSize).enumerated()
-            .forEach { (chunkIndex, chunk) in
-                
-                group.enter()
-                
-                self.searchQueue.async {
-                    for (index, item) in chunk.enumerated() {
-                        var scores = [Double]()
-                        var totalScore = 0.0
-                        
-                        var propertyResults = [(value: String, diffScore: Double, ranges: [CountableClosedRange<Int>])]()
-                        
-                        item[keyPath: keyPath].forEach { property in
-                            let value = property.value
-                            
-                            if let result = self.search(pattern, in: value) {
-                                let weight = property.weight == 1 ? 1 : 1 - property.weight
-                                let score = result.score * weight
-                                totalScore += score
-                                
-                                scores.append(score)
-                                
-                                propertyResults.append((value: property.value, diffScore: score, ranges: result.ranges))
-                            }
-                        }
-                        
-                        if scores.count == 0 {
-                            continue
-                        }
-                        
-                        resultLock.lock()
-                        collectionResult.append((
-                            index: chunkIndex * chunkSize + index,
-                            diffScore: self.objSortStrategy == .averageScore ? totalScore / Double(scores.count) : scores.min() ?? 1,
-                            results: propertyResults
-                        ))
-                        resultLock.unlock()
-                    }
-                    
-                    group.leave()
-                }
-            }
-        
-        group.notify(queue: self.searchQueue) {
-            let sorted = collectionResult.sorted { $0.diffScore < $1.diffScore }
-            DispatchQueue.main.async {
-                completion(sorted)
-            }
-        }
+        let fuseProps = aList.lazy.map({item in
+            item[keyPath: keyPath]
+        })
+        self.search(text, in: fuseProps, chunkSize: chunkSize, completion: completion)
     }
     
     ///

--- a/Sources/Ifrit/Classes/Fuse+/Fuse+FuseProps.swift
+++ b/Sources/Ifrit/Classes/Fuse+/Fuse+FuseProps.swift
@@ -1,0 +1,157 @@
+//
+//  Fuse+FuseProps.swift
+//
+
+import Foundation
+
+extension Fuse {
+    ///
+    /// instructions how to use: https://github.com/ukushu/Ifrit/blob/main/Docs/FuseInstructions.md
+    ///
+    public func searchSync<S: Sequence>(_ text: String, in aList: S) -> [FuzzySrchResult] where S.Element == [FuseProp] {
+        let pattern = self.createPattern(from: text)
+
+        var collectionResult = [FuzzySrchResult]()
+
+        for (index, item) in aList.enumerated() {
+            var scores = [Double]()
+            var totalScore = 0.0
+
+            var propertyResults = [(value: String, diffScore: Double, ranges: [CountableClosedRange<Int>])]()
+
+            item.forEach { property in
+
+                let value = property.value
+
+                if let result = self.search(pattern, in: value) {
+                    let weight = property.weight == 1 ? 1 : 1 - property.weight
+                    let score = (result.score == 0 && weight == 1 ? 0.001 : result.score) * weight
+                    totalScore += score
+
+                    scores.append(score)
+
+                    propertyResults.append((value: property.value, diffScore: score, ranges: result.ranges))
+                }
+            }
+
+            if scores.count == 0 {
+                continue
+            }
+
+            collectionResult.append((
+                index: index,
+                diffScore: self.objSortStrategy == .averageScore ? totalScore / Double(scores.count) : scores.min() ?? 1 ,
+                results: propertyResults
+            ))
+        }
+
+        return collectionResult.sorted { $0.diffScore < $1.diffScore }
+    }
+    
+    ///
+    /// instructions how to use: https://github.com/ukushu/Ifrit/blob/main/Docs/FuseInstructions.md
+    ///
+    @Sendable
+    public func search<S: Sequence>(_ text: String, in aList: S,
+                          chunkSize: Int = 100,
+                          completion: @escaping @Sendable ([FuzzySrchResult]) -> Void) where S.Element == [FuseProp]
+    {
+        let iterator = aList.makeIterator()
+
+        let lazyChunkSequence = sequence(state: iterator) {
+            iter -> [[FuseProp]]? in
+
+            var currentChunk: [[FuseProp]] = []
+            currentChunk.reserveCapacity(chunkSize)
+
+            for _ in 0..<chunkSize {
+                if let element = iter.next() {
+                    currentChunk.append(element)
+                } else {
+                    break
+                }
+            }
+
+            return currentChunk.isEmpty ? nil : currentChunk
+        }
+
+        searchChunks(text, in: AnySequence(lazyChunkSequence), chunkSize: chunkSize, completion: completion)
+    }
+    
+    @Sendable
+    internal func searchChunks<S: Sequence>(_ text: String, in aList: S,
+                                                   chunkSize: Int = 100,
+                          completion: @escaping @Sendable ([FuzzySrchResult]) -> Void) where S.Element == [[FuseProp]]
+    {
+        let pattern = self.createPattern(from: text )
+
+        let group = DispatchGroup()
+
+        var collectionResult = [FuzzySrchResult]()
+        let resultLock = NSLock()
+
+        aList.enumerated()
+            .forEach { (chunkIndex, chunk) in
+
+                group.enter()
+
+                self.searchQueue.async {
+                    for (index, item) in chunk.enumerated() {
+                        var scores = [Double]()
+                        var totalScore = 0.0
+
+                        var propertyResults = [(value: String, diffScore: Double, ranges: [CountableClosedRange<Int>])]()
+
+                        item.forEach { property in
+                            let value = property.value
+
+                            if let result = self.search(pattern, in: value) {
+                                let weight = property.weight == 1 ? 1 : 1 - property.weight
+                                let score = result.score * weight
+                                totalScore += score
+
+                                scores.append(score)
+
+                                propertyResults.append((value: property.value, diffScore: score, ranges: result.ranges))
+                            }
+                        }
+
+                        if scores.count == 0 {
+                            continue
+                        }
+
+                        resultLock.lock()
+                        collectionResult.append((
+                            index: chunkIndex * chunkSize + index,
+                            diffScore: self.objSortStrategy == .averageScore ? totalScore / Double(scores.count) : scores.min() ?? 1,
+                            results: propertyResults
+                        ))
+                        resultLock.unlock()
+                    }
+
+                    group.leave()
+                }
+            }
+
+        group.notify(queue: self.searchQueue) {
+            let sorted = collectionResult.sorted { $0.diffScore < $1.diffScore }
+            DispatchQueue.main.async {
+                completion(sorted)
+            }
+        }
+    }
+    
+    ///
+    /// instructions how to use: https://github.com/ukushu/Ifrit/blob/main/Docs/FuseInstructions.md
+    ///
+    public func search(_ text: String,
+                       in aList: [[FuseProp]],
+                       chunkSize: Int = 100) async -> [FuzzySrchResult]
+    {
+        await withCheckedContinuation { continuation in
+            search(text, in: aList, chunkSize: 100) { results in
+                continuation.resume(returning: results)
+            }
+        }
+    }
+}


### PR DESCRIPTION
In this PR, I've introduced a way to search a sequence of arrays of FuseProps. This API allows Ifrit to search objects without adding an extension to them, which makes Ifrit's API more generally useful. For example, it's now possible to use Ifrit to search an array of dictionaries, by lazily mapping them to arrays of FuseProps, without adding an extension to dictionaries in general.

I also think this API is easier to learn and understand. 

When I first started learning Ifrit (as a relative newbie Swift user) I was _very_ confused by its API for searching objects. The `Searchable` protocol has no content; instead, users have to define a custom property (with no defined name) that returns an array of FuseProps, and then refer to that property by key path. It was a struggle understanding the documentation for that reason.

The documentation now begins by introducing how to search arrays of FuseProps, and how to lazily map an array of simple structs to arrays of FuseProps. Once the user understands what FuseProps are and how to use them, it's a simpler next step to understand how to add an extension property that returns arrays of FuseProps.

Fuse+ArrObjects is now implemented based on Fuse+FuseProps, and all tests pass (except for #11, fixed in a separate PR).