### PR TITLE
Change default `objSortStrategy` to `.minimalScore`

### DIFF
--- a/Sources/Ifrit/Classes/Fuse.swift
+++ b/Sources/Ifrit/Classes/Fuse.swift
@@ -22,7 +22,7 @@ public class Fuse: @unchecked Sendable {
     ///   - tokenize: When true, the search algorithm will search individual words **and** the full string, computing the final score as a function of both. Note that when `tokenize` is `true`, the `threshold`, `distance`, and `location` are inconsequential for individual tokens.
     ///    `objSortStrategy:` if you search in object by property with array - you can choose your sorting strategy.  By default is `.minimalScore`.
     ///   - qos: quality-of-service, use this to set search task priority. Better never use `.user-interactive`. By default is `.userInitiated`.
-    public init (location: Int = 0, distance: Int = 100, threshold: Double = 0.6, isCaseSensitive: Bool = false, tokenize: Bool = false, objSortStrategy: ObjectsSortStrategy = .averageScore, qos: DispatchQoS = .userInitiated) {
+    public init (location: Int = 0, distance: Int = 100, threshold: Double = 0.6, isCaseSensitive: Bool = false, tokenize: Bool = false, objSortStrategy: ObjectsSortStrategy = .minimalScore, qos: DispatchQoS = .userInitiated) {
         self.location = location
         self.distance = distance
         self.threshold = threshold

--- a/Tests/Ifrit_FuseTests/Fuse_TestsTokenize.swift
+++ b/Tests/Ifrit_FuseTests/Fuse_TestsTokenize.swift
@@ -63,8 +63,8 @@ class Fuse_TestsTokenize: XCTestCase {
     
     func testProtocolWeightedSearchTokenized() {
         let books: [Book] = [
+            Book(author: "P.D. Mans", title: "Right Ho Jeeves"),
             Book(author: "John X", title: "Old Man's War fiction"),
-            Book(author: "P.D. Mans", title: "Right Ho Jeeves")
         ]
         
         let fuse = Fuse(tokenize: true)


### PR DESCRIPTION
**Backwards incompatible, breaking change**

In 6cde912 `objSortStrategy` was introduced, allowing users to choose whether to sort by average score or minimal score. Prior to that commit, Ifrit would always sort objects by their average score.

But the commit also changed the default `objSortStrategy` to `.minimalScore`, breaking backwards compatibility and breaking one of the automated tests.

In #12, we reverted the default to `.averageScore`, but `.minimalScore` is more intuitive.

This commit un-reverts the default back to `.minimalScore`, and updates the test to match the new expectation.