### PR TITLE
Support searching objects with a (T) -> [FuseProp] closure

### DIFF
--- a/Documentation/FuseInstructions.md
+++ b/Documentation/FuseInstructions.md
@@ -78,7 +78,7 @@ fuse.search("Te silm", in: books, completion: { results in
 })
 ```
 
-#### Search in `[[FuseProp]]`
+#### Search in objects by `(T) -> [FuseProp]` closure
 
 A `FuseProp` is a struct of searchable values and the weights to assign to them.
 
@@ -109,35 +109,19 @@ let books: [Book] = [
 ]
 ```
 
-You could convert each book to an array of `FuseProp` objects and search them like this:
-
-```swift
-class Book: Searchable {
-    var namesUkr: [String]
-    var namesEng: [String]
-    var namesEngBritan: [String]
-    
-    public var srchUkrNamesProp: [FuseProp] {
-        namesUkr
-            .distinct()
-            .map { FuseProp($0) }
-    }
-    
-    public var srchEngNamesProp: [FuseProp] {
-        namesEng
-            .appending(contentsOf: namesEngBritan)
-            .distinct()
-            .map { FuseProp($0) }
-    }
-}
-```
+To search them, you can provide a closure, which will convert each book into an array of FuseProps.
 
 ```swift
 let fuse = Fuse()
 
 // --------------------
 // SYNC version
-let resultsSync = fuse.searchSync("man", in: booksDb, by: \Book.srchEngNamesProp)
+let resultsSync = fuse.searchSync("man", in: books) { book in
+    [
+        FuseProp(value: book.title),
+        FuseProp(value: book.author),
+    ]
+}
 
 resultsSync.forEach { item in
     print("index: \(item.index); score: \(item.diffScore)")
@@ -145,14 +129,24 @@ resultsSync.forEach { item in
 
 // --------------------
 // ASYNC: async/await
-let resultsAsync = await fuse.search("man", in: booksDb, by: \Book.srchEngNamesProp)
+let resultsAsync = await fuse.search("man", in: books) { book in
+    [
+        FuseProp(value: book.title),
+        FuseProp(value: book.author),
+    ]
+}
 
 resultsAsync.forEach { item in
     print("index: \(item.index); score: \(item.diffScore)")
 }
 
 // ASYNC: callbacks
-fuse.search("Man", in: booksDb, by: \Book.srchEngNamesProp, completion: { results in
+fuse.search("Man", in: books, by:  { book in
+    [
+        FuseProp(value: book.title),
+        FuseProp(value: book.author),
+    ]
+}, completion: { results in
     results.forEach { item in
         print("index: \(item.index); score: \(item.diffScore)")
     }
@@ -162,15 +156,15 @@ fuse.search("Man", in: booksDb, by: \Book.srchEngNamesProp, completion: { result
 You can also add weights to your `FuseProp` objects. This example would prioritize author matches over title matches:
 
 ```swift
-let fuseProps = books.map({book in 
+let resultsSync = fuse.searchSync("man", in: books) { book in
     [
         FuseProp(value: book.title, weight: 0.3),
         FuseProp(value: book.author, weight: 0.7),
     ]
-})
+}
 ```
 
-#### Search in `[Searchable]` objects
+#### Search in `[Searchable]` objects by key path
 
 Declaration of `Searchable` object:
 
@@ -225,8 +219,7 @@ struct Library: Fuseable {
 }
 ```
 
-
-#### Search in `[Searchable]` objects
+Now, you're ready to search your Searchable objects by key path.
 
 ```swift
 // --------------------

--- a/Sources/Ifrit/Classes/Fuse+/Fuse+ArrObjects.swift
+++ b/Sources/Ifrit/Classes/Fuse+/Fuse+ArrObjects.swift
@@ -6,10 +6,27 @@ extension Fuse {
     ///
     /// instructions how to use: https://github.com/ukushu/Ifrit/blob/main/Docs/FuseInstructions.md
     ///
+    public func searchSync<T>(_ text: String, in aList: [T], by propertyExtractor: @escaping (T) -> [FuseProp]) -> [FuzzySrchResult]  where T: Searchable {
+        return self.searchSync(text, in: aList.lazy.map(propertyExtractor))
+    }
+    
+    ///
+    /// instructions how to use: https://github.com/ukushu/Ifrit/blob/main/Docs/FuseInstructions.md
+    ///
     public func searchSync<T>(_ text: String, in aList: [T], by keyPath: KeyPath<T, [FuseProp]>) -> [FuzzySrchResult]  where T: Searchable {
-        return self.searchSync(text, in: aList.lazy.map({item in
-            item[keyPath: keyPath]
-        }))
+        return self.searchSync(text, in: aList) { item in item[keyPath: keyPath] }
+    }
+    
+    ///
+    /// instructions how to use: https://github.com/ukushu/Ifrit/blob/main/Docs/FuseInstructions.md
+    ///
+    @Sendable
+    public func search<T: Sendable>(_ text: String, in aList: [T],
+                          by propertyExtractor: @escaping (T) -> [FuseProp],
+                          chunkSize: Int = 100,
+                          completion: @escaping @Sendable ([FuzzySrchResult]) -> Void) where T: Searchable
+    {
+        self.search(text, in: aList.lazy.map(propertyExtractor), chunkSize: chunkSize, completion: completion)
     }
     
     ///
@@ -21,10 +38,24 @@ extension Fuse {
                           chunkSize: Int = 100,
                           completion: @escaping @Sendable ([FuzzySrchResult]) -> Void) where T: Searchable
     {
-        let fuseProps = aList.lazy.map({item in
+        self.search(text, in: aList, by: {item in
             item[keyPath: keyPath]
-        })
-        self.search(text, in: fuseProps, chunkSize: chunkSize, completion: completion)
+        }, chunkSize: chunkSize, completion: completion)
+    }
+    
+    ///
+    /// instructions how to use: https://github.com/ukushu/Ifrit/blob/main/Docs/FuseInstructions.md
+    ///
+    public func search<T: Sendable>(_ text: String,
+                       in aList: [T],
+                       chunkSize: Int = 100,
+                       by propertyExtractor: @escaping (T) -> [FuseProp]) async -> [FuzzySrchResult] where T: Searchable
+    {
+        await withCheckedContinuation { continuation in
+            search(text, in: aList, by: propertyExtractor, chunkSize: 100) { results in
+                continuation.resume(returning: results)
+            }
+        }
     }
     
     ///
@@ -36,7 +67,7 @@ extension Fuse {
                        chunkSize: Int = 100) async -> [FuzzySrchResult] where T: Searchable
     {
         await withCheckedContinuation { continuation in
-            search(text, in: aList, by: keyPath, chunkSize: 100) { results in
+            search(text, in: aList, by: {item in item[keyPath: keyPath]}, chunkSize: 100) { results in
                 continuation.resume(returning: results)
             }
         }

--- a/Tests/Ifrit_FuseTests/Fuse_TestsBasic.swift
+++ b/Tests/Ifrit_FuseTests/Fuse_TestsBasic.swift
@@ -102,6 +102,30 @@ class Fuse_TestsBasic: XCTestCase {
         XCTAssert(results[1].index == 0, "The second result is the first book")
     }
     
+    func testProtocolWeightedSearch3() {
+        struct Book: Searchable {
+            let author: String
+            let title: String
+        }
+        
+        let books: [Book] = [
+            Book(author: "John X", title: "Old Man's War fiction"),
+            Book(author: "P.D. Mans", title: "Right Ho Jeeves")
+        ]
+        
+        let fuse = Fuse()
+        let results = fuse.searchSync("man", in: books) {book in
+            return [
+                FuseProp(book.author, weight: 0.7),
+                FuseProp(book.title, weight: 0.3)
+            ]
+        }
+        
+        XCTAssert(results.count > 0, "There are results")
+        XCTAssert(results[0].index == 1, "The first result is the second book")
+        XCTAssert(results[1].index == 0, "The second result is the first book")
+    }
+    
     func test_CorrectIdOfObject_ProperiesArraysSearchSync() {
         let animes: [Anime] = largeAnimeArray()
         


### PR DESCRIPTION
```swift
let resultsSync = fuse.searchSync("man", in: books) { book in
    [
        FuseProp(value: book.title),
        FuseProp(value: book.author),
    ]
}
```

I've also updated the documentation to document this closure-based method first, and then to document the key path method, which I think is more powerful, but harder to learn.

All tests pass.

Fixes #15